### PR TITLE
Refactor AddRedis Extension method

### DIFF
--- a/FeedR.sln
+++ b/FeedR.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Gateway", "Gateway", "{73603290-74A9-4147-A3B5-90C076EC0E20}"
 EndProject
@@ -15,35 +15,50 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "News", "News", "{4C26177A-2
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{5D7DBE28-A2D7-4942-899D-C17894FE0495}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Gateway", "src\Gateway\FeedR.Gateway\FeedR.Gateway.csproj", "{7B726B90-8AB4-4553-AAE5-20FB622B030A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Gateway", "src\Gateway\FeedR.Gateway\FeedR.Gateway.csproj", "{7B726B90-8AB4-4553-AAE5-20FB622B030A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Aggregator", "Aggregator", "{2DF17BCB-EB9B-4AAA-8EE2-7EAB4203F3EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Aggregator", "src\Aggregator\FeedR.Aggregator\FeedR.Aggregator.csproj", "{E4A1F0AE-1C3E-4E0F-8B87-F03BD89344B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Aggregator", "src\Aggregator\FeedR.Aggregator\FeedR.Aggregator.csproj", "{E4A1F0AE-1C3E-4E0F-8B87-F03BD89344B0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Notifier", "Notifier", "{15C0DCEC-449D-460C-AFBF-F39DA1F77C83}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Notifier", "src\Notifier\FeedR.Notifier\FeedR.Notifier.csproj", "{1D0A5E71-4BF2-4263-B151-0260B429A9D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Notifier", "src\Notifier\FeedR.Notifier\FeedR.Notifier.csproj", "{1D0A5E71-4BF2-4263-B151-0260B429A9D3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Shared", "src\Shared\FeedR.Shared\FeedR.Shared.csproj", "{953DC0CB-F3B1-4369-A2B1-AA5B2297B652}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Shared", "src\Shared\FeedR.Shared\FeedR.Shared.csproj", "{953DC0CB-F3B1-4369-A2B1-AA5B2297B652}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Feeds.News", "src\Feeds\News\FeedR.Feeds.News\FeedR.Feeds.News.csproj", "{9D4E3D64-D2FB-4CB8-AE53-E4F4A08C4F7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Feeds.News", "src\Feeds\News\FeedR.Feeds.News\FeedR.Feeds.News.csproj", "{9D4E3D64-D2FB-4CB8-AE53-E4F4A08C4F7B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Feeds.Quotes", "src\Feeds\Quotes\FeedR.Feeds.Quotes\FeedR.Feeds.Quotes.csproj", "{C554D03E-4FEC-4C3B-A6DC-607798ABCEBA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Feeds.Quotes", "src\Feeds\Quotes\FeedR.Feeds.Quotes\FeedR.Feeds.Quotes.csproj", "{C554D03E-4FEC-4C3B-A6DC-607798ABCEBA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Feeds.Weather", "src\Feeds\Weather\FeedR.Feeds.Weather\FeedR.Feeds.Weather.csproj", "{C003E6EF-C36F-4F29-87C4-D47754112C11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Feeds.Weather", "src\Feeds\Weather\FeedR.Feeds.Weather\FeedR.Feeds.Weather.csproj", "{C003E6EF-C36F-4F29-87C4-D47754112C11}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Clients", "Clients", "{73D756FE-24FA-4F59-BE76-F2E3C456E74D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeedR.Clients.Console", "src\Clients\Console\FeedR.Clients.Console\FeedR.Clients.Console.csproj", "{F2D81437-F72D-4BA4-92A4-F3D4F02C72A7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeedR.Clients.Console", "src\Clients\Console\FeedR.Clients.Console\FeedR.Clients.Console.csproj", "{F2D81437-F72D-4BA4-92A4-F3D4F02C72A7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2589C868-BC28-4338-95D8-19BB5CE03E5F}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		FeedR.rest = FeedR.rest
+		compose\infrastructure.yml = compose\infrastructure.yml
+		LICENSE = LICENSE
+		pm2.yml = pm2.yml
+		README.md = README.md
+		compose\services.yml = compose\services.yml
+		tye.yml = tye.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "compose", "compose", "{E419D9E1-7EDD-4B5C-A2C5-50BB075E808D}"
+	ProjectSection(SolutionItems) = preProject
+		compose\infrastructure.yml = compose\infrastructure.yml
+		compose\services.yml = compose\services.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7B726B90-8AB4-4553-AAE5-20FB622B030A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -79,6 +94,9 @@ Global
 		{F2D81437-F72D-4BA4-92A4-F3D4F02C72A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2D81437-F72D-4BA4-92A4-F3D4F02C72A7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7FA77029-BF01-4A1E-80DE-91A63C5684E1} = {6DC5BF4D-4F52-4C5A-9475-71A94088D333}
 		{97D2D4A8-7F68-4D6A-8090-199DC73C2B1A} = {6DC5BF4D-4F52-4C5A-9475-71A94088D333}
@@ -91,5 +109,9 @@ Global
 		{C554D03E-4FEC-4C3B-A6DC-607798ABCEBA} = {7FA77029-BF01-4A1E-80DE-91A63C5684E1}
 		{C003E6EF-C36F-4F29-87C4-D47754112C11} = {97D2D4A8-7F68-4D6A-8090-199DC73C2B1A}
 		{F2D81437-F72D-4BA4-92A4-F3D4F02C72A7} = {73D756FE-24FA-4F59-BE76-F2E3C456E74D}
+		{E419D9E1-7EDD-4B5C-A2C5-50BB075E808D} = {2589C868-BC28-4338-95D8-19BB5CE03E5F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FEA378E3-6E19-45E9-B41C-3EAFF9F1D11A}
 	EndGlobalSection
 EndGlobal

--- a/src/Shared/FeedR.Shared/Redis/Extensions.cs
+++ b/src/Shared/FeedR.Shared/Redis/Extensions.cs
@@ -6,16 +6,34 @@ namespace FeedR.Shared.Redis;
 
 public static class Extensions
 {
-    public static IServiceCollection AddRedis(this IServiceCollection services, IConfiguration configuration)
+    /// <summary>
+    /// Adds Redis to <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <remarks>
+    /// Uses the lower-level <see cref="ServiceDescriptor"/> APIs to acquire an instance of <see cref="IConfiguration"/>
+    /// without the need of passing it in explicitly
+    /// </remarks>
+    /// <returns>The same <see cref="IServiceCollection"/> instance.</returns>
+    public static IServiceCollection AddRedis(this IServiceCollection services)
     {
-        var section = configuration.GetRequiredSection("redis");
-        var options = new RedisOptions();
-        section.Bind(options);
-        services.Configure<RedisOptions>(section);
-        services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(options.ConnectionString));
-        
+        var serviceDescriptor = ServiceDescriptor.Singleton<IConnectionMultiplexer>(sp =>
+        {
+            var options = sp.GetRequiredService<IConfiguration>().GetRequiredSection("redis").Get<RedisOptions>();
+            return ConnectionMultiplexer.Connect(options.ConnectionString);
+        });
+
+        services.Add(serviceDescriptor);
+
         return services;
     }
-    
-    
+
+    /// <summary>
+    /// Adds Redis to <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <returns>The same <see cref="IServiceCollection"/> instance.</returns>
+    [Obsolete("Use the overload that does not take the IConfiguration explicitely")]
+    public static IServiceCollection AddRedis(this IServiceCollection services, IConfiguration configuration)
+    {
+        return AddRedis(services);
+    }
 }


### PR DESCRIPTION
This PR refactors the `AddRedis` extension method to fetch the `IConfiguration` from the already built _ServiceCollection_ (the `IServiceProvider`) instead of relying on the explicitly passed `IConfiguration`.

Pros:
* Does not require the user to pass in an `IConfiguration` instance

Cons:
* Does not register the `RedisOptions` via the _Options pattern_ so there will be no way to inject an `IOptions<RedisOptions>` in arbitrary services; but since the type is only used in configuring an `IConnectionMultiplexer`, this can be safely overlooked.